### PR TITLE
fix documentation links

### DIFF
--- a/R/element-markdown.R
+++ b/R/element-markdown.R
@@ -10,18 +10,18 @@
 #' @param box.colour,box.color Line color of the enclosing box (if different from the text color)
 #' @param linetype Line type of the enclosing box (like `lty` in base R)
 #' @param linewidth Line width of the enclosing box (measured in mm, just like `size` in
-#'   [`element_line()`]).
+#'   [ggplot2::element_line()]).
 #' @param hjust Horizontal justification
 #' @param vjust Vertical justification
 #' @param halign Horizontal justification
 #' @param valign Vertical justification
 #' @param lineheight Line height
 #' @param padding,margin Padding and margins around the text box.
-#'   See [`richtext_grob()`] for details.
+#'   See [gridtext::richtext_grob()] for details.
 #' @param r Unit value specifying the corner radius of the box 
 #' @param angle Angle (in degrees)
 #' @param align_widths,align_heights Should multiple elements be aligned by their
-#'   widths or height? See [`richtext_grob()`] for details.
+#'   widths or height? See [gridtext::richtext_grob()] for details.
 #' @param rotate_margins Should margins get rotated in frame with rotated text?
 #'   If `TRUE`, the margins are applied relative to the text direction. If `FALSE`,
 #'   the margins are applied relative to the plot direction, i.e., the top margin,
@@ -29,8 +29,8 @@
 #'   in which the text runs. The default is `FALSE`, which mimics the behavior of 
 #'   `element_text()`.
 #' @param debug Draw a debugging box around each label
-#' @param inherit.blank See [`margin()`] for details.
-#' @seealso [`richtext_grob()`], [`element_textbox()`]
+#' @param inherit.blank See [ggplot2::margin()] for details.
+#' @seealso [gridtext::richtext_grob()], [element_textbox()]
 #' @export
 element_markdown <- function(family = NULL, face = NULL, size = NULL, colour = NULL, fill = NULL,
                              box.colour = NULL, linetype = NULL, linewidth = NULL,

--- a/R/element-textbox.R
+++ b/R/element-textbox.R
@@ -16,23 +16,23 @@
 #' @param box.colour,box.color Line color of the enclosing box (if different from the text color)
 #' @param linetype Line type of the enclosing box (like `lty` in base R)
 #' @param linewidth Line width of the enclosing box (measured in mm, just like `size` in
-#'   [`element_line()`]).
+#'   [ggplot2::element_line()]).
 #' @param hjust Horizontal justification
 #' @param vjust Vertical justification
 #' @param halign Horizontal justification
 #' @param valign Vertical justification
 #' @param lineheight Line height
 #' @param width,height Unit objects specifying the width and height
-#'   of the textbox, as in [textbox_grob()].
+#'   of the textbox, as in [gridtext::textbox_grob()].
 #' @param minwidth,minheight,maxwidth,maxheight Min and max values for width and height.
 #'   Set to NULL to impose neither a minimum nor a maximum.
 #' @param padding,margin Padding and margins around the text box.
-#'   See [`textbox_grob()`] for details.
+#'   See [gridtext::textbox_grob()] for details.
 #' @param r Unit value specifying the corner radius of the box 
-#' @param orientation Orientation of the text box. See [`textbox_grob()`] for details.
+#' @param orientation Orientation of the text box. See [gridtext::textbox_grob()] for details.
 #' @param debug Not implemented.
-#' @param inherit.blank See [`margin()`] for details.
-#' @seealso [`textbox_grob()`], [`element_markdown()`]
+#' @param inherit.blank See [ggplot2::margin()] for details.
+#' @seealso [gridtext::textbox_grob()], [element_markdown()]
 #' @examples
 #' library(ggplot2)
 #' 

--- a/R/geom-richtext.R
+++ b/R/geom-richtext.R
@@ -1,6 +1,6 @@
 #' Rich text labels
 #'
-#' This draws text labels similar to [`ggplot2::geom_label()`], but formatted
+#' This draws text labels similar to [ggplot2::geom_label()], but formatted
 #' using basic markdown/html.
 #' 
 #' @inheritParams ggplot2::geom_text

--- a/man/element_markdown.Rd
+++ b/man/element_markdown.Rd
@@ -47,7 +47,7 @@ element_markdown(
 \item{linetype}{Line type of the enclosing box (like \code{lty} in base R)}
 
 \item{linewidth}{Line width of the enclosing box (measured in mm, just like \code{size} in
-\code{\link[=element_line]{element_line()}}).}
+\code{\link[ggplot2:element_line]{ggplot2::element_line()}}).}
 
 \item{hjust}{Horizontal justification}
 
@@ -62,12 +62,12 @@ element_markdown(
 \item{lineheight}{Line height}
 
 \item{padding, margin}{Padding and margins around the text box.
-See \code{\link[=richtext_grob]{richtext_grob()}} for details.}
+See \code{\link[gridtext:richtext_grob]{gridtext::richtext_grob()}} for details.}
 
 \item{r}{Unit value specifying the corner radius of the box}
 
 \item{align_widths, align_heights}{Should multiple elements be aligned by their
-widths or height? See \code{\link[=richtext_grob]{richtext_grob()}} for details.}
+widths or height? See \code{\link[gridtext:richtext_grob]{gridtext::richtext_grob()}} for details.}
 
 \item{rotate_margins}{Should margins get rotated in frame with rotated text?
 If \code{TRUE}, the margins are applied relative to the text direction. If \code{FALSE},
@@ -78,11 +78,11 @@ in which the text runs. The default is \code{FALSE}, which mimics the behavior o
 
 \item{debug}{Draw a debugging box around each label}
 
-\item{inherit.blank}{See \code{\link[=margin]{margin()}} for details.}
+\item{inherit.blank}{See \code{\link[ggplot2:margin]{ggplot2::margin()}} for details.}
 }
 \description{
 Theme element that enables markdown text.
 }
 \seealso{
-\code{\link[=richtext_grob]{richtext_grob()}}, \code{\link[=element_textbox]{element_textbox()}}
+\code{\link[gridtext:richtext_grob]{gridtext::richtext_grob()}}, \code{\link[=element_textbox]{element_textbox()}}
 }

--- a/man/element_textbox.Rd
+++ b/man/element_textbox.Rd
@@ -81,7 +81,7 @@ element_textbox_simple(
 \item{linetype}{Line type of the enclosing box (like \code{lty} in base R)}
 
 \item{linewidth}{Line width of the enclosing box (measured in mm, just like \code{size} in
-\code{\link[=element_line]{element_line()}}).}
+\code{\link[ggplot2:element_line]{ggplot2::element_line()}}).}
 
 \item{hjust}{Horizontal justification}
 
@@ -94,21 +94,21 @@ element_textbox_simple(
 \item{lineheight}{Line height}
 
 \item{padding, margin}{Padding and margins around the text box.
-See \code{\link[=textbox_grob]{textbox_grob()}} for details.}
+See \code{\link[gridtext:textbox_grob]{gridtext::textbox_grob()}} for details.}
 
 \item{width, height}{Unit objects specifying the width and height
-of the textbox, as in \code{\link[=textbox_grob]{textbox_grob()}}.}
+of the textbox, as in \code{\link[gridtext:textbox_grob]{gridtext::textbox_grob()}}.}
 
 \item{minwidth, minheight, maxwidth, maxheight}{Min and max values for width and height.
 Set to NULL to impose neither a minimum nor a maximum.}
 
 \item{r}{Unit value specifying the corner radius of the box}
 
-\item{orientation}{Orientation of the text box. See \code{\link[=textbox_grob]{textbox_grob()}} for details.}
+\item{orientation}{Orientation of the text box. See \code{\link[gridtext:textbox_grob]{gridtext::textbox_grob()}} for details.}
 
 \item{debug}{Not implemented.}
 
-\item{inherit.blank}{See \code{\link[=margin]{margin()}} for details.}
+\item{inherit.blank}{See \code{\link[ggplot2:margin]{ggplot2::margin()}} for details.}
 }
 \description{
 The theme elements \code{element_textbox()} and \code{element_textbox_simple()} enable Markdown text in a box, with
@@ -163,5 +163,5 @@ geom_point() +
   )
 }
 \seealso{
-\code{\link[=textbox_grob]{textbox_grob()}}, \code{\link[=element_markdown]{element_markdown()}}
+\code{\link[gridtext:textbox_grob]{gridtext::textbox_grob()}}, \code{\link[=element_markdown]{element_markdown()}}
 }


### PR DESCRIPTION
I was not able to use remotes to install the package. And I was not able to build the package locally from the git repository.

```
==> Rcmd.exe INSTALL --no-multiarch --with-keep.source ggtext

* installing to library 'C:/Users/Tristan/Documents/R/win-library/3.5'
* installing *source* package 'ggtext' ...
** using staged installation
** R
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
converting help for package 'ggtext'
element_markdown                        html      finding HTML links ... done

finding level-2 HTML links ...
Error: unknown input format
* removing 'C:/Users/Tristan/Documents/R/win-library/3.5/ggtext'
* restoring previous 'C:/Users/Tristan/Documents/R/win-library/3.5/ggtext'

Exited with status 1.
```

The package installation worked when I disabled roxygen's markdown flag. That made me think it was the links. So I added namespace to the external functions and removes the redundant backticks in the links (links to functions are automatically converted to code). Now the package builds successfully.

```
==> Rcmd.exe INSTALL --no-multiarch --with-keep.source ggtext

* installing to library 'C:/Users/Tristan/Documents/R/win-library/3.5'
* installing *source* package 'ggtext' ...
** using staged installation
** R
** byte-compile and prepare package for lazy loading
** help
*** installing help indices
  converting help for package 'ggtext'
    element_markdown                        html      finding HTML links ... done

Rd warning: F:/Tristan/Documents/GitRepos2/ggtext/man/element_markdown.Rd:50: file link 'element_line' in package 'ggplot2' does not exist and so has been treated as a topic
Rd warning: F:/Tristan/Documents/GitRepos2/ggtext/man/element_markdown.Rd:81: file link 'margin' in package 'ggplot2' does not exist and so has been treated as a topic
    element_textbox                         html  
Rd warning: F:/Tristan/Documents/GitRepos2/ggtext/man/element_textbox.Rd:84: file link 'element_line' in package 'ggplot2' does not exist and so has been treated as a topic
Rd warning: F:/Tristan/Documents/GitRepos2/ggtext/man/element_textbox.Rd:111: file link 'margin' in package 'ggplot2' does not exist and so has been treated as a topic
    geom_richtext                           html  
Rd warning: F:/Tristan/Documents/GitRepos2/ggtext/man/geom_richtext.Rd:83: file link 'geom_label' in package 'ggplot2' does not exist and so has been treated as a topic
    geom_textbox                            html  
    ggtext                                  html  
*** copying figures
** building package indices
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (ggtext)
```